### PR TITLE
ARCH-1615 - Update syntax for setting outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Get Status
       id: get-status
-      uses: 'im-open/iis-site-status@v2.0.2'
+      uses: 'im-open/iis-site-status@v2.1.0'
       with:
         server: ${{ env.server }}
         website-name: ${{ env.website-name }}

--- a/iis_action.ps1
+++ b/iis_action.ps1
@@ -39,10 +39,10 @@ $script_result = Invoke-Command -ComputerName $server `
 
 If ($script_result -and $script_result -eq 1) {
     Write-Output "IIS Site Status Error"
-    Write-Output "website-status=IIS Site Status Error" >> $GITHUB_OUTPUT
+    "website-status=IIS Site Status Error" >> $env:GITHUB_OUTPUT
     Exit 1
 }
 else {
     Write-Output "$display_action_past_tense."
-    Write-Output "website-status=$script_result" >> $GITHUB_OUTPUT
+    "website-status=$script_result" >> $env:GITHUB_OUTPUT
 }

--- a/iis_action.ps1
+++ b/iis_action.ps1
@@ -39,10 +39,10 @@ $script_result = Invoke-Command -ComputerName $server `
 
 If ($script_result -and $script_result -eq 1) {
     Write-Output "IIS Site Status Error"
-    Write-Output "::set-output name=website-status::IIS Site Status Error"
+    Write-Output "website-status=IIS Site Status Error" >> $GITHUB_OUTPUT
     Exit 1
 }
 else {
     Write-Output "$display_action_past_tense."
-    Write-Output "::set-output name=website-status::$script_result"
+    Write-Output "website-status=$script_result" >> $GITHUB_OUTPUT
 }


### PR DESCRIPTION
# Summary of PR changes

-  Update syntax for setting outputs to comply with the [GitHub's new recommendations](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands) to avoid logging untrusted data.
- The syntax is slightly different than the normal bash syntax because the outputs are set in powershell.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
